### PR TITLE
Adds gitlab ci configuration

### DIFF
--- a/.gitlab-ci.yaml
+++ b/.gitlab-ci.yaml
@@ -1,0 +1,15 @@
+stages:
+  - build
+  - test
+
+build-code-job:
+  stage: build
+  script:
+    - ls -la
+
+test-code-job1:
+  stage: test
+  script:
+    - git clone git@github.com:ShaddGallegos/RHTI.git
+    - chmod +x ./RHTI/Satellite/files/REDHATTOOLSINSTALLER-6.8-10272020.sh
+    - ./RHTI/Satellite/files/REDHATTOOLSINSTALLER-6.8-10272020.sh


### PR DESCRIPTION
This change adds the CI/CD configuration file so that the downstream gitlab ci infra will run builds for the installer.